### PR TITLE
ci : add shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 - make test
 - make vet
 - make website-test
+- make shellcheck
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
 
 cache:
   directories:
-  - $GOPATH/src
   - $HOME/.cache/go-build
   - $HOME/gopath/pkg/mod
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,6 +25,9 @@ vet:
 		exit 1; \
 	fi
 
+shellcheck:
+	shellcheck scripts/*
+
 fmt:
 	gofmt -w $(GOFMT_FILES)
 

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -11,21 +11,21 @@
 set -e
 
 if [[ ! -f CHANGELOG.md ]]; then
-  echo "ERROR: CHANGELOG.md not found in pwd."
-  echo "Please run this from the root of the terraform provider repository"
-  exit 1
+    echo "ERROR: CHANGELOG.md not found in pwd."
+    echo "Please run this from the root of the terraform provider repository"
+    exit 1
 fi
 
-if [[ `uname` == "Darwin" ]]; then
-  echo "Using BSD sed"
-  SED="sed -i.bak -E -e"
+if [[ $(uname) == "Darwin" ]]; then
+    echo "Using BSD sed"
+    SED="sed -i.bak -E -e"
 else
-  echo "Using GNU sed"
-  SED="sed -i.bak -r -e"
+    echo "Using GNU sed"
+    SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-statuscake\/issues"
+PROVIDER_URL="https:\\/\\/github.com\\/terraform-providers\\/terraform-provider-statuscake\\/issues"
 
-$SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
+$SED "s/GH-([0-9]+)/\\[#\\1\\]\\($PROVIDER_URL\\/\\1\\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 
 rm CHANGELOG.md.bak

--- a/scripts/errcheck.sh
+++ b/scripts/errcheck.sh
@@ -3,7 +3,7 @@
 # Check gofmt
 echo "==> Checking for unchecked errors..."
 
-if ! which errcheck > /dev/null; then
+if ! command -v errcheck > /dev/null; then
     echo "==> Installing errcheck..."
     go get -u github.com/kisielk/errcheck
 fi
@@ -12,7 +12,7 @@ err_files=$(errcheck -ignoretests \
                      -ignore 'github.com/hashicorp/terraform/helper/schema:Set' \
                      -ignore 'bytes:.*' \
                      -ignore 'io:Close|Write' \
-                     $(go list ./...| grep -v /vendor/))
+                     "$(go list ./...| grep -v /vendor/)")
 
 if [[ -n ${err_files} ]]; then
     echo 'Unchecked errors found in the following places:'

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+gofmt_files=$(gofmt -l "$(find . -name '*.go' | grep -v vendor)")
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"

--- a/scripts/gogetcookie.sh
+++ b/scripts/gogetcookie.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
- touch ~/.gitcookies
- chmod 0600 ~/.gitcookies
+touch ~/.gitcookies
+chmod 0600 ~/.gitcookies
 
- git config --global http.cookiefile ~/.gitcookies
+git config --global http.cookiefile ~/.gitcookies
 
- tr , \\t <<\__END__ >>~/.gitcookies
+tr , \\t <<\__END__ >>~/.gitcookies
 .googlesource.com,TRUE,/,TRUE,2147483647,o,git-alexandre.namebla.gmail.com=1/OtfvUDYg3VAHfIxaqjAuv8MJqu6--gSU_zSkD8YkKPc
+__END__


### PR DESCRIPTION
Add shellcheck to the makeffile and .travis.yml and fix the scripts to have no error with it.
Fixed the whitespaces in scripts/gogetcookie.sh.
Travis cached too many files, it has been fixed.
Closes #9 
gofmt is already run by make test with the script scripts/gofmtcheck.sh.