### PR TITLE
fix the tests and ensure the ips are fetched correctly

### DIFF
--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -21,7 +21,7 @@ type fullDomain struct {
 }
 
 func getFullDomain(mg *mailgun.MailgunImpl, domainName string) (*fullDomain, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
 	defer cancel()
 	mg = mailgun.NewMailgun(domainName, mg.APIKey())
 
@@ -42,7 +42,8 @@ func getFullDomain(mg *mailgun.MailgunImpl, domainName string) (*fullDomain, err
 		return nil, fmt.Errorf("Error Getting mailgun domain tracking Details for %s: Error: %s", domainName, err)
 	}
 
-	ipAddress, err := mg.ListDomainIPS(ctx)
+	ipAddress, err := getIps(ctx, mg)
+
 	if err != nil {
 		return nil, fmt.Errorf("Error Getting mailgun domain ips2 for %s: Error: %s", domainName, err)
 	}
@@ -209,7 +210,7 @@ func testAccDomainCheckDestroy(domain *fullDomain) resource.TestCheckFunc {
 		mg := testAccProvider.Meta().(*mailgun.MailgunImpl)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 		defer cancel()
-
+		time.Sleep(5 * time.Second)
 		_, err := mg.GetDomain(ctx, domain.domainResponse.Domain.Name)
 		if err == nil {
 			return fmt.Errorf("domain still exists")


### PR DESCRIPTION
The ips are now fetched correctly.
A sleep was put in the destroy check to ensure that the api have time to destroy before it is checked.
Closes #15 